### PR TITLE
[@mantine/dates] TimePicker: Fix min/max values not being enforced fo…

### DIFF
--- a/packages/@docs/demos/src/demos/dates/TimePicker/TimePicker.demo.minMax.tsx
+++ b/packages/@docs/demos/src/demos/dates/TimePicker/TimePicker.demo.minMax.tsx
@@ -5,12 +5,22 @@ const code = `
 import { TimePicker } from '@mantine/dates';
 
 function Demo() {
-  return <TimePicker label="Enter time" min="10:00" max="18:30" />;
+  return (
+    <>
+      <TimePicker label="Enter time (24h format)" min="10:00" max="18:30" />
+      <TimePicker label="Enter time (12h format)" min="10:00" max="18:30" format="12h" mt="md" />
+    </>
+  );
 }
 `;
 
 function Demo() {
-  return <TimePicker label="Enter time" min="10:00" max="18:30" />;
+  return (
+    <>
+      <TimePicker label="Enter time (24h format)" min="10:00" max="18:30" />
+      <TimePicker label="Enter time (12h format)" min="10:00" max="18:30" format="12h" mt="md" />
+    </>
+  );
 }
 
 export const minMax: MantineDemo = {

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.story.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.story.tsx
@@ -158,7 +158,23 @@ export function MinMax() {
 
   return (
     <div style={{ padding: 40 }}>
-      <TimePicker min="10:30" max="18:30" format="12h" value={value} onChange={setValue} />
+      <TimePicker
+        min="10:30"
+        max="18:30"
+        format="12h"
+        value={value}
+        onChange={setValue}
+        label="12h format"
+      />
+      <div>{value}</div>
+      <TimePicker
+        min="10:30"
+        max="18:30"
+        format="24h"
+        value={value}
+        onChange={setValue}
+        label="24h format"
+      />
       <div>{value}</div>
     </div>
   );

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.test.tsx
@@ -296,6 +296,9 @@ describe('@mantine/dates/TimePicker', () => {
     await userEvent.type(screen.getByLabelText('test-hours'), '7');
     await userEvent.type(screen.getByLabelText('test-minutes'), '30');
     await userEvent.type(screen.getByLabelText('test-seconds'), '0');
+    expect(spy).toHaveBeenCalledWith('07:30:00');
+
+    await userEvent.tab();
     expect(spy).toHaveBeenCalledWith('08:30:00');
 
     await userEvent.clear(screen.getByLabelText('test-hours'));
@@ -306,6 +309,9 @@ describe('@mantine/dates/TimePicker', () => {
     await userEvent.type(screen.getByLabelText('test-hours'), '19');
     await userEvent.type(screen.getByLabelText('test-minutes'), '30');
     await userEvent.type(screen.getByLabelText('test-seconds'), '0');
+    expect(spy).toHaveBeenCalledWith('19:30:00');
+
+    await userEvent.tab();
     expect(spy).toHaveBeenCalledWith('18:30:00');
   });
 
@@ -326,6 +332,9 @@ describe('@mantine/dates/TimePicker', () => {
     await userEvent.type(screen.getByLabelText('test-minutes'), '30');
     await userEvent.type(screen.getByLabelText('test-seconds'), '0');
     await userEvent.type(screen.getByLabelText('test-am-pm'), 'A');
+    expect(spy).toHaveBeenCalledWith('07:30:00');
+
+    await userEvent.tab();
     expect(spy).toHaveBeenCalledWith('08:30:00');
 
     await userEvent.clear(screen.getByLabelText('test-hours'));
@@ -337,6 +346,9 @@ describe('@mantine/dates/TimePicker', () => {
     await userEvent.type(screen.getByLabelText('test-minutes'), '30');
     await userEvent.type(screen.getByLabelText('test-seconds'), '0');
     await userEvent.type(screen.getByLabelText('test-am-pm'), 'P');
+    expect(spy).toHaveBeenCalledWith('19:30:00');
+
+    await userEvent.tab();
     expect(spy).toHaveBeenCalledWith('18:30:00');
   });
 

--- a/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
+++ b/packages/@mantine/dates/src/components/TimePicker/TimePicker.tsx
@@ -35,7 +35,9 @@ import {
 } from './TimePicker.types';
 import { TimePresets } from './TimePresets/TimePresets';
 import { useTimePicker } from './use-time-picker';
+import { clampTime } from './utils/clamp-time/clamp-time';
 import { getParsedTime } from './utils/get-parsed-time/get-parsed-time';
+import { getTimeString } from './utils/get-time-string/get-time-string';
 import classes from './TimePicker.module.css';
 
 export type TimePickerStylesNames =
@@ -312,6 +314,21 @@ export const TimePicker = factory<TimePickerFactory>((_props, ref) => {
 
   const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
     if (!event.currentTarget.contains(event.relatedTarget)) {
+      const computedValue = controller.values;
+      const timeString = getTimeString({
+        ...computedValue,
+        format,
+        amPmLabels,
+        withSeconds: !!withSeconds,
+      });
+
+      if (timeString.valid && min && max) {
+        const clamped = clampTime(timeString.value, min, max);
+
+        if (clamped.timeString !== timeString.value) {
+          controller.setTimeString(clamped.timeString);
+        }
+      }
       hasFocusRef.current = false;
       onBlur?.(event);
     }

--- a/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
+++ b/packages/@mantine/dates/src/components/TimePicker/use-time-picker.ts
@@ -100,8 +100,7 @@ export function useTimePicker({
         setAmPm(val);
       }
 
-      const clamped = clampTime(timeString.value, min || '00:00:00', max || '23:59:59');
-      onChange?.(clamped.timeString);
+      onChange?.(timeString.value);
     } else {
       acceptChange.current = false;
       if (typeof value === 'string' && value !== '') {


### PR DESCRIPTION
…r 12h time format (#8107)

The time is clamped between min and max when the TimePicker element loses focus.